### PR TITLE
Give the CI job the right name

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: CI
 
 on:
   push:


### PR DESCRIPTION
... so it can display properly in the badges we're adding. :-)))